### PR TITLE
Next up: new schema (the PR deploy will fail, please don't be alarmed)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,23 +10,11 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-enum EventType {
+enum ConvoType {
   JUNTO
-  INTERVIEW // @note could be "unlisted" @anggxyz
+  INTERVIEW
   TEST
-}
-
-// deprecated -- donot use Communities anywhere
-model Community {
-  id          String   @id @default(uuid())
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-  displayName String
-  description String
-  subdomain   String   @unique
-  events      Event[]
-  slack       Slack?
-  google      Google?
+  UNLISTED
 }
 
 enum LocationType {
@@ -35,49 +23,36 @@ enum LocationType {
   CUSTOM
 }
 
-model Event {
+model Convo {
   id              String       @id @default(uuid())
   createdAt       DateTime     @default(now())
   updatedAt       DateTime     @updatedAt
   title           String
   descriptionHtml String?
-  startDateTime   DateTime
-  endDateTime     DateTime
-  location        String
-  locationType    LocationType @default(ONLINE)
-  hash            String // @note deprecated
-  series          Boolean // @note deprecated
+  slug            String
   limit           Int
-  rrule           String?
-  sequence        Int          @default(0)
-  // for deleted events
-  // can be purged periodically
   isDeleted       Boolean      @default(false)
-  // google
-  // gCalEventRequested Boolean      @default(false) // remove, deprecated
-  gCalEventId     String? // KEEP, DONT REMOVE
-  // gCalId             String? // remove, deprecated
-  type            EventType    @default(JUNTO)
+  type            ConvoType    @default(JUNTO)
   proposerId      String
   proposer        User         @relation(fields: [proposerId], references: [id], onDelete: Cascade)
   rsvps           Rsvp[]
   collections     Collection[]
   reminders       Email[]
-  // deprecated
-  communityId     String?
-  // deprecated
-  community       Community?   @relation(fields: [communityId], references: [id])
-  // if the event was imported from convo.kernel.community
-  // if it was, we do not have their RSVPs, since this version uses
-  // user's addresses to make them unique and the previous version used
-  // email addresses
-  // having isImported = true, means
-  // the UI will show an info box mentioning "This event was imported from the previous version of the app
-  // and the total number of RSVPs might not be accurate. Please email
-  // if you'd like to query any data related to RSVPs for this particular event"
-  // the emails[], gcaleventREquested, gcalEventId will be accurate for these events
-  // the proposer data will be inaccurate
-  isImported      Boolean      @default(false)
+  sessions        Session[]
+}
+
+model Session {
+  id            String       @id @default(uuid())
+  createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @updatedAt
+  startDateTime DateTime
+  endDateTime   DateTime
+  rrule         String?
+  sequence      Int          @default(0)
+  location      String
+  locationType  LocationType @default(ONLINE)
+  convoId       String
+  convo         Convo        @relation(fields: [convoId], references: [id])
 }
 
 model User {
@@ -86,7 +61,7 @@ model User {
   address     String?      @unique // deprecated
   nickname    String       @default("Anonymous")
   profile     Profile?
-  events      Event[]
+  convos      Convo[]
   rsvps       Rsvp[]
   collections Collection[]
   reminders   Email[]
@@ -108,19 +83,19 @@ model Collection {
   name      String
   userId    String
   user      User     @relation(fields: [userId], references: [id])
-  events    Event[]
+  convos    Convo[]
 }
 
 model Rsvp {
   id         String    @id @default(uuid())
   createdAt  DateTime  @default(now())
-  eventId    String
-  event      Event     @relation(fields: [eventId], references: [id])
+  convoId    String
+  convo      Convo     @relation(fields: [convoId], references: [id])
   attendeeId String
   attendee   User      @relation(fields: [attendeeId], references: [id])
   rsvpType   RSVP_TYPE @default(GOING)
 
-  @@unique([eventId, attendeeId])
+  @@unique([convoId, attendeeId])
 }
 
 enum RSVP_TYPE {
@@ -138,8 +113,8 @@ model Email {
   createdAt  DateTime  @default(now())
   userId     String
   user       User      @relation(fields: [userId], references: [id])
-  eventId    String
-  event      Event     @relation(fields: [eventId], references: [id])
+  convoId    String
+  convo      Convo     @relation(fields: [convoId], references: [id])
   reminderId String    @unique // Resend scheduled email id
   type       EmailType
   sent       Boolean   @default(false)
@@ -158,36 +133,9 @@ enum EmailType {
   REMINDER1HRPROPOSER
 }
 
-// @deprecated
-model Google {
-  id                      String     @id @default(uuid())
-  createdAt               DateTime   @default(now())
-  // credentials
-  clientId                String
-  projectId               String
-  authUri                 String
-  tokenUri                String
-  authProviderX509CertUrl String
-  clientSecret            String
-  redirectUris            String[]
-  javascriptOrigins       String[]
-  // token
-  accessToken             String
-  refreshToken            String
-  scope                   String
-  tokenType               String
-  expiryDate              String
-  // the calendar to send events to
-  calendarId              String?
-  communityId             String?    @unique // one google service is associated with 1 community
-  community               Community? @relation(references: [id], fields: [communityId])
-}
-
 model Slack {
-  id          String     @id @default(uuid())
-  createdAt   DateTime   @default(now())
-  botToken    String
-  channel     String
-  communityId String?    @unique // one slack instance is associated with 1 community
-  community   Community? @relation(references: [id], fields: [communityId])
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  botToken  String
+  channel   String
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,8 +33,7 @@ model Convo {
   limit           Int
   isDeleted       Boolean      @default(false)
   type            ConvoType    @default(JUNTO)
-  proposerId      String
-  proposer        User         @relation(fields: [proposerId], references: [id], onDelete: Cascade)
+  proposers       User[]
   rsvps           Rsvp[]
   collections     Collection[]
   reminders       Email[]


### PR DESCRIPTION
- cleaned up the database to remove deprecated fields
- make sessions a 1:m association with Convo
- rename Event to Convo
- Convo can be a collection of Sessions
