### PR TITLE
Removed online default from 'where' for now + cleaned up fonts

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -143,7 +143,7 @@ const Where = ({
         <CardTitle className="text-base">where</CardTitle>
         {!isUserGoing && (
           <CardDescription>
-            <span className="text-xs text-gray-500">RSVP to see location</span>
+            <span className="text-xs text-gray-500"> </span>
           </CardDescription>
         )}
       </CardHeader>
@@ -155,13 +155,7 @@ const Where = ({
               : event.location
             : null}
           {!(isUserGoing || isOwnerOfConvo) && (
-            <span className="font-mono text-sm text-gray-500">
-              somewhere{" "}
-              <span className="italic">
-                {" "}
-                {parseConvoLocation(event.locationType)}
-              </span>
-            </span>
+            <span className="text-sm text-gray-500">RSVP to see location</span>
           )}
         </div>
       </CardContent>


### PR DESCRIPTION
Closes #286 

'Somewhere Online' is the current default, given we no longer ask for it in the Propose flow 

I thought we could solve this by switching the 'RSVP to see location' helper text to the main message (which I think is better).

Later, if we add back 'Online / IRL' location types, that can show up as helper text.  

<img width="467" alt="image" src="https://github.com/user-attachments/assets/813cd506-6fb0-4e75-91fc-460f923e4fc2" />

![RSVP to see location](https://github.com/user-attachments/assets/400b82cb-caa7-4ccf-bfbd-704f8f7172af)

 