### PR TITLE
Fixed typo in RSVP 'No' Email

### DIFF
--- a/src/components/Email/templates/InviteNotGoing.tsx
+++ b/src/components/Email/templates/InviteNotGoing.tsx
@@ -2,7 +2,7 @@ import type { EmailTemplateWithEventProps } from "../types";
 import { EmailWrapper } from "../components/EmailWrapper";
 import { EventDetails } from "../components/EventDetails";
 
-export const SUBJECT = "Can&apos;t make it to {{event.title}}";
+export const SUBJECT = "Can't make it to {{event.title}}";
 
 export const InviteNotGoingEmailTemplate: React.FC<
   Readonly<EmailTemplateWithEventProps>


### PR DESCRIPTION
Fixes #289.

<img width="433" alt="image" src="https://github.com/user-attachments/assets/654eaa1a-1315-466c-8bd5-5b376a38c3f9" />

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/56079085-3b9c-4a34-b0cb-60a07a01646b" />
