### PR TITLE
Add hyperlink in 'Where' field, increase string limit to 100

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -150,15 +150,33 @@ const Where = ({
       <CardContent>
         <div className="rounded-xl bg-slate-400/10 px-2 py-1 text-sm text-gray-500 transition-all duration-300 hover:bg-slate-400/20">
           {(isUserGoing || isOwnerOfConvo) && event.location
-            ? event.location.length > 20
-              ? event.location.substring(0, 20) + "..."
-              : event.location
+            ? (() => {
+                try {
+                  new URL(event.location); // If this succeeds, it's a valid URL
+                  return (
+                    <a
+                      href={event.location}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-500 underline"
+                    >
+                      {event.location.length > 100
+                        ? event.location.substring(0, 100) + "..."
+                        : event.location}
+                    </a>
+                  );
+                } catch {
+                  return event.location.length > 100
+                    ? event.location.substring(0, 100) + "..."
+                    : event.location;
+                }
+              })()
             : null}
+
           {!(isUserGoing || isOwnerOfConvo) && (
             <span className="font-mono text-sm text-gray-500">
               somewhere{" "}
               <span className="italic">
-                {" "}
                 {parseConvoLocation(event.locationType)}
               </span>
             </span>


### PR DESCRIPTION
Fixes #316.

- Links in the 'where' field are now defaulted to hyperlinks. 
- String limit increased to 100 (confirmed that there is no 'overflow'). 

Code changes were localized to this particular of the codebase, with the help of GPT, to reduce any possible downstream effects. 

![Hyperlinks in 'Where'](https://github.com/user-attachments/assets/d50a1f7e-90cf-4592-b54f-30a283596458)