### PR TITLE
Copy Emails To Clipboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "18.2.0",
         "react-hook-form": "^7.42.1",
+        "react-hot-toast": "^2.5.2",
         "react-icons": "^4.9.0",
         "react-intersection-observer": "^9.4.1",
         "react-map-gl": "^8.0.2",
@@ -14591,10 +14592,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/d": {
       "version": "1.0.1",
@@ -17385,6 +17385,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/google-auth-library": {
@@ -22902,6 +22910,22 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.42.1",
+    "react-hot-toast": "^2.5.2",
     "react-icons": "^4.9.0",
     "react-intersection-observer": "^9.4.1",
     "react-map-gl": "^8.0.2",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import Providers from "./providers";
 import type { Metadata } from "next";
 import { BetaModeWrapper } from "src/components/BetaModeWrapper";
 import "mapbox-gl/dist/mapbox-gl.css"; // Import Mapbox CSS
+import { Toaster } from "react-hot-toast";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -150,6 +151,27 @@ export default function RootLayout({
             <Providers isBetaMode={isBetaMode}>
               <ScrambleProvider>
                 <div vaul-drawer-wrapper="">{children}</div>
+                <Toaster
+                  position="bottom-right"
+                  toastOptions={{
+                    style: {
+                      background: "var(--background)",
+                      color: "var(--foreground)",
+                      border: "1px solid var(--border)",
+                      fontSize: "0.875rem",
+                      maxWidth: "320px",
+                      padding: "0.75rem 1rem",
+                      fontFamily: "var(--font-inter)",
+                    },
+                    success: {
+                      duration: 3000,
+                      iconTheme: {
+                        primary: "var(--primary)",
+                        secondary: "var(--primary-foreground)",
+                      },
+                    },
+                  }}
+                />
               </ScrambleProvider>
             </Providers>
           )}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,7 +1,13 @@
 import type { ClientEvent } from "src/types";
 import { InfoBox } from "./InfoBox";
 import { useRef } from "react";
-import { ChevronDown, MessageCircle, Plus, WrenchIcon } from "lucide-react";
+import {
+  ChevronDown,
+  MessageCircle,
+  Plus,
+  WrenchIcon,
+  Copy,
+} from "lucide-react";
 import { AddRsvpCredenza } from "./AddRsvpCredenza";
 import { MessageCredenza } from "./MessageCredenza";
 import {
@@ -46,6 +52,7 @@ import { cleanupRruleString } from "src/utils/cleanupRruleString";
 import { rrulestr } from "rrule";
 import { ArrowUpRight } from "lucide-react";
 import { AlertCircle } from "lucide-react";
+import { toast } from "react-hot-toast";
 
 const When = ({
   event,
@@ -848,13 +855,30 @@ const AdminMetricsAccordion = ({ event }: { event: ClientEvent }) => {
                     </select>
                   </div>
                   {filteredRsvps.length > 0 && (
-                    <div className="relative">
+                    <div className="flex items-center gap-2">
                       <button
                         onClick={() => setShowMessageInput(!showMessageInput)}
                         className="bg-primary/10 hover:bg-primary/20 flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1 text-primary-foreground transition-colors"
                       >
                         <MessageCircle className="h-4 w-4" />
                         Message?
+                      </button>
+                      <button
+                        onClick={() => {
+                          const emails = filteredRsvps
+                            .map((rsvp) => rsvp.attendee.email)
+                            .join(", ");
+                          navigator.clipboard.writeText(emails);
+                          toast.success(
+                            `${filteredRsvps.length} email${
+                              filteredRsvps.length === 1 ? "" : "s"
+                            } copied to clipboard`
+                          );
+                        }}
+                        className="bg-primary/10 hover:bg-primary/20 flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1 text-primary-foreground transition-colors"
+                      >
+                        <Copy className="h-4 w-4" />
+                        Copy Emails
                       </button>
                       <MessageCredenza
                         isOpen={showMessageConfirm}
@@ -901,7 +925,6 @@ const AdminMetricsAccordion = ({ event }: { event: ClientEvent }) => {
                           }
                         }}
                       />
-                      <AnimatePresence></AnimatePresence>
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
For both hosts & stewards, copy all emails from the admin dashboard. 

- Only copies emails in the current filter (All, Going, Not Going, Maybe)
- Cursor added a nice little pop-up for us along the way using something called `toast`

Fixes #332

![Copy Emails With Toast Pop-Up](https://github.com/user-attachments/assets/f19a92e0-0eaf-43be-9752-3ca42a358b86)
