### PR TITLE
Fixes edits to event series where one event is already in the past

### DIFF
--- a/src/utils/rrule.ts
+++ b/src/utils/rrule.ts
@@ -1,0 +1,12 @@
+/**
+ * Helper functions for working with RRule (recurrence rules)
+ */
+
+/**
+ * Cleans up an RRULE string by removing any DTSTART component
+ * This is necessary because we set the DTSTART explicitly when creating RRule objects
+ */
+export function cleanupRruleString(rruleString: string): string {
+  // Remove any DTSTART component as we'll set it explicitly
+  return rruleString.replace(/DTSTART:[^\n]+\n?/i, "");
+}


### PR DESCRIPTION
Fixes #342 (I think) 

- Fixes edits to event series where one event is in the past
- There was a 'recurrence rule' that held us up from editing past events
- That meant event series with one event in the past could not be edited 

- This PR allows for edits to these series, while retaining that recurrence rule for standalone events (can't edit events in the past)

Notes: 
- Hard to test bc no event series in dev environment where one event is in the past
- Small change, though, with simple solution from Cursor, so we decided to merge 
- Test case will be: can I edit [this event](https://www.convo.cafe/rsvp/jEmK_UhObi) to move it one hour up?