### PR TITLE
Archive: Show past events in reverse chronological order and add seed data for testing

### DIFF
--- a/src/app/api/query/getEvents/route.ts
+++ b/src/app/api/query/getEvents/route.ts
@@ -154,7 +154,7 @@ export async function POST(request: NextRequest) {
             ...defaultWheres,
           },
           orderBy: {
-            startDateTime: "desc",
+            startDateTime: "desc", // Most recent first
           },
         });
       }

--- a/src/app/archive/page.tsx
+++ b/src/app/archive/page.tsx
@@ -8,24 +8,8 @@ const Archive: NextPage = () => {
   return (
     <>
       <Main>
-        <div
-          className="
-          px-6
-          md:px-12
-          lg:px-32
-        "
-        >
-          <div
-            className="
-              dark:text-primary-dark
-              font-primary
-              text-4xl
-              font-semibold
-              lowercase text-primary
-              sm:text-5xl
-              lg:py-5
-            "
-          >
+        <div className="px-6 md:px-12 lg:px-32">
+          <div className="dark:text-primary-dark font-primary text-4xl font-semibold lowercase text-primary sm:text-5xl lg:py-5">
             Archive
           </div>
           <Events
@@ -40,4 +24,5 @@ const Archive: NextPage = () => {
     </>
   );
 };
+
 export default Archive;

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -205,14 +205,17 @@ export const Events = ({
       // Group events by day
       const groupedEvents = _.groupBy(eventsWithProcessedDates, "dayKey");
 
-      // Sort the dates chronologically
+      // Sort the dates chronologically, respecting the type (past events should be newest first)
       return Object.entries(groupedEvents).sort(
         ([dateA], [dateB]) =>
-          DateTime.fromISO(dateA).toMillis() -
-          DateTime.fromISO(dateB).toMillis()
+          type === "past"
+            ? DateTime.fromISO(dateB).toMillis() -
+              DateTime.fromISO(dateA).toMillis() // newest first for past events
+            : DateTime.fromISO(dateA).toMillis() -
+              DateTime.fromISO(dateB).toMillis() // oldest first for other types
       );
     };
-  }, []);
+  }, [type]); // Add type to dependencies since we're using it in the sort
 
   return (
     <>


### PR DESCRIPTION
Smol fix: bringing back https://www.convo.cafe/archive so it works. Fixes #293 

Now the archive page should correctly show:
- Past events only
- Most recent events first
- Events grouped by day, with the most recent days at the top

Changes made to: 
- `prisma/seed.ts` - Added past events for testing [think this might come in handy in other testing, too]
- `src/app/api/query/getEvents/route.ts`- Simplified past events query
- `src/app/archive/page.tsx` - Archive page implementation
- `src/components/Events.tsx` - Sorting changes for past events
